### PR TITLE
HDF-115 strings in search results is stripped for html tags

### DIFF
--- a/src/components/InputSearch.js
+++ b/src/components/InputSearch.js
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 import URLSearchParams from 'url-search-params';
 import useInterval from '../js/hooks/useInterval';
 
+import stripStringForHtmlUtil from './../utils/stripStringForHtmlUtil';
+
 const searchPageUrl = process.env.REACT_APP_ENONICXP_SEARCH_RESULT_PAGE
   ? process.env.REACT_APP_ENONICXP_SEARCH_RESULT_PAGE
   : '/søkeresultat';
@@ -26,7 +28,7 @@ const renderSuggestion = suggestion => (
       </div>
     )}
     {suggestion.intro && (
-      <div className="suggestion-intro">{suggestion.intro}</div>
+      <div className="suggestion-intro">{stripStringForHtmlUtil(suggestion.intro)}</div>
     )}
     {suggestion.topic && (
       <div className="suggestion-topic">{suggestion.topic}</div>

--- a/src/faas/simpleSearch.js
+++ b/src/faas/simpleSearch.js
@@ -43,6 +43,13 @@ const allItems = [
     url: 'http://norge.no'
   },
   {
+    title: 'æøå - html',
+    category: 'news',
+    publishDate: '2. April 2015',
+    intro: '<p><b>Test av norske bokstaver</b>, æøå i html tags <script></script></p>\n',
+    url: 'http://norge.no'
+  },
+  {
     title: 'This is news #5',
     category: 'news',
     publishDate: '5. April 2018',

--- a/src/utils/stripStringForHtmlUtil.js
+++ b/src/utils/stripStringForHtmlUtil.js
@@ -1,0 +1,10 @@
+// Takes a string and strips all html tags in it
+// https://stackoverflow.com/questions/5002111/how-to-strip-html-tags-from-string-in-javascript
+const stripStringForHtmlUtil = (string) => {
+  const div = document.createElement("div");
+  div.innerHTML = string;
+  const strippedString = div.textContent || div.innerText || "";
+  return strippedString;
+}
+
+export default stripStringForHtmlUtil;

--- a/src/utils/stripStringForHtmlUtil.test.js
+++ b/src/utils/stripStringForHtmlUtil.test.js
@@ -1,0 +1,22 @@
+import stripStringForHtmlUtil from './stripStringForHtmlUtil';
+
+describe('stripStringForHtmlUtil', () => {
+  it('should return string without html tags', () => {
+    const testString = '<p><b>Test </b>, æøå i html tags</p>';
+    const expectedString = 'Test , æøå i html tags'
+    const testStringResult = stripStringForHtmlUtil(testString)
+    expect(testStringResult).toBe(expectedString);
+  })
+  it('should return string without html tags', () => {
+    const testString = '<p><b>Test </b>, æøå i html tags</p> <img onerror="alert(\'could run arbitrary JS here\')" src=bogus>';
+    const expectedString = 'Test , æøå i html tags '
+    const testStringResult = stripStringForHtmlUtil(testString)
+    expect(testStringResult).toBe(expectedString);
+  })
+  it('should return string if only a string is sent', () => {
+    const testString = 'Test is best with hest';
+    const expectedString = 'Test is best with hest';
+    const testStringResult = stripStringForHtmlUtil(testString)
+    expect(testStringResult).toBe(expectedString);
+  })
+})


### PR DESCRIPTION
There are cases where strings from search results contains html tag. These tags needs to be removed.

A util that removes html tags from strings has been created with corresponding tests