### PR TITLE
Collapsible should always get a heading (not a 'div'), and the editor…

### DIFF
--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -166,7 +166,7 @@ Collapsible.propTypes = {
   subheading: PropTypes.string,
   subheadingContent: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  h: PropTypes.oneOf(['h0', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
+  h: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
   smallContent: PropTypes.bool,
   subtle: PropTypes.bool,
   category: PropTypes.string,

--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -34,7 +34,12 @@ const headingClasses = (size, bold) =>
     h3: size === 'large',
     h4: size === 'medium',
     normal: size === 'small',
-    'h0--bold': bold // a hack :( one special case they want the header to be bold
+    // These additional 'bold' classes are here because HDIR wants to keep semantic choices whilst
+    //  still having control over 'bold' styles on headings.
+    //  Note that one has to explicitly specify if the 'bold' prop is false. Leaving it undefined
+    //  won't set the 'h0--hormal' class to the heading
+    'h0--bold': bold === true,
+    'h0--normal': bold === false
   });
 
 const collapsibleClasses = (size, subtle, noBorder) =>
@@ -84,7 +89,7 @@ const Collapsible = props => {
     } else {
       if (props.size === 'large') return 'h2';
       else if (props.size === 'medium') return 'h3';
-      else if (props.size === 'small') return 'h0';
+      else if (props.size === 'small') return 'h4';
     }
   };
 
@@ -127,6 +132,7 @@ const Collapsible = props => {
               heading={props.subheading}
               subtle={Boolean(props.subheadingContent)}
               size="small"
+              bold={props.bold}
               smallContent
             >
               <p>{props.subheadingContent}</p>

--- a/src/pages/TreatmentPageA.js
+++ b/src/pages/TreatmentPageA.js
@@ -138,7 +138,7 @@ const TreatmentPageA = () => (
                           heading="Beskrivelse av aktiviteten"
                           size="small"
                           id={shortid.generate()}
-                          bold
+                          bold={false}
                         >
                           <p>abc abc abc.</p>
                         </Collapsible>
@@ -147,7 +147,7 @@ const TreatmentPageA = () => (
                           heading="Begrunnelse"
                           size="small"
                           id={shortid.generate()}
-                          bold
+                          bold={false}
                         >
                           <p>abc abc abc.</p>
                         </Collapsible>
@@ -156,7 +156,7 @@ const TreatmentPageA = () => (
                           heading="Informasjon til pasienten"
                           size="small"
                           id={shortid.generate()}
-                          bold
+                          bold={false}
                         >
                           <p>abc abc abc.</p>
                         </Collapsible>

--- a/src/styles/_headings.scss
+++ b/src/styles/_headings.scss
@@ -50,13 +50,13 @@ h5,
 }
 
 // Heading weights
+.h0, // 'h0' is only used to reset styles on dynamic headings we don't know the type of
 .h1,
 .h2,
 .h3,
 .h4,
 .h5,
-.h6,
-.h0 {
+.h6 {
   &--light {
     font-weight: lighter;
   }


### PR DESCRIPTION
… should be able to choose if the heading shows as bold or not