### PR TITLE
Render images inline (with a 'img' tag) when the article does not use…

### DIFF
--- a/src/components/ArticleIntro.js
+++ b/src/components/ArticleIntro.js
@@ -26,23 +26,33 @@ const ArticleIntro = props => (
     </div>
     {props.image && (
       <div className={imageWrapperClasses(props.feature)}>
-        <div
-          className="b-article-intro__image"
-          style={{ backgroundImage: `url(${props.image})` }}
-          role="img"
-          aria-labelledby="intro-image-description"
-        />
         {!props.feature ? (
-          <p
-            className="b-article-intro__image-text"
-            id="intro-image-description"
-          >
-            {props.imageDescription}
-          </p>
+          <>
+            <img
+              className="b-article-intro__image"
+              src={props.image}
+              alt={props.imageDescription}
+              aria-labelledby="intro-image-description"
+            />
+            <p
+              className="b-article-intro__image-text"
+              id="intro-image-description"
+            >
+              {props.imageDescription}
+            </p>
+          </>
         ) : (
-          <div className="visually-hidden" id="intro-image-description">
-            {props.imageDescription}
-          </div>
+          <>
+            <div
+              className="b-article-intro__image"
+              style={{ backgroundImage: `url(${props.image})` }}
+              role="img"
+              aria-labelledby="intro-image-description"
+            />
+            <div className="visually-hidden" id="intro-image-description">
+              {props.imageDescription}
+            </div>
+          </>
         )}
       </div>
     )}

--- a/src/styles/_b-article-intro.scss
+++ b/src/styles/_b-article-intro.scss
@@ -9,21 +9,31 @@
   }
 
   &__image {
-    width: 100%;
+    // This applies both on a 'img' tag and a 'div' tag with background
     max-width: 100%;
     height: 100%;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: 50% 50%;
+    &-wrapper--feature & {
+      // This applies only on a 'div' tag with background
+      width: 100%;
+      background-repeat: no-repeat;
+      background-size: cover;
+      background-position: 50% 50%;
+    }
 
     @include mq($until: $tablet) {
       height: 33vh;
     }
   }
   &__image-wrapper {
+    // This wraps both a 'img' and a 'div' tag with background
     width: calc(50% - 1.5rem);
     margin-left: 1.5rem;
     min-height: 12.5vw;
+    max-height: 220px;
+    &--feature & {
+      // This wraps only a 'div' tag with background
+      max-height: auto;
+    }
 
     @include mq($until: $tablet) {
       width: 100%;


### PR DESCRIPTION
… a 'featured' article intro